### PR TITLE
Add /save command to save chat history

### DIFF
--- a/neogpt/utils/magic_commands.py
+++ b/neogpt/utils/magic_commands.py
@@ -1,4 +1,5 @@
 # Import necessary modules
+import os
 from langchain_community.chat_message_histories.in_memory import ChatMessageHistory
 from rich.console import Console
 from langchain.schema import HumanMessage
@@ -56,6 +57,16 @@ def magic_commands(user_input, chain):
 
         return True
 
+    # If the user inputs '/save', save the chat history to a file
+    elif user_input == "/save":
+        with open('docs/chat_history.txt', 'w') as f:
+            for message in chain.combine_documents_chain.memory.chat_memory.messages:
+                if isinstance(message, HumanMessage):
+                    f.write(f"{get_username()} {message.content}\n")
+                else:
+                    f.write(f"NeoGPT: {message.content}\n")
+        cprint("Chat history saved to docs/chat_history.txt")
+        return True
 
     # If the command is not recognized, print an error message
     else:

--- a/neogpt/utils/magic_commands.py
+++ b/neogpt/utils/magic_commands.py
@@ -1,5 +1,5 @@
 # Import necessary modules
-import os
+import datetime
 from langchain_community.chat_message_histories.in_memory import ChatMessageHistory
 from rich.console import Console
 from langchain.schema import HumanMessage
@@ -59,13 +59,15 @@ def magic_commands(user_input, chain):
 
     # If the user inputs '/save', save the chat history to a file
     elif user_input == "/save":
-        with open('docs/chat_history.txt', 'w') as f:
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f'chat_history_{timestamp}.txt'
+        with open(filename, 'w') as f:
             for message in chain.combine_documents_chain.memory.chat_memory.messages:
                 if isinstance(message, HumanMessage):
                     f.write(f"{get_username()} {message.content}\n")
                 else:
                     f.write(f"NeoGPT: {message.content}\n")
-        cprint("Chat history saved to docs/chat_history.txt")
+        cprint(f"Chat history saved as {filename}")
         return True
 
     # If the command is not recognized, print an error message


### PR DESCRIPTION
This pull request adds a new command, `/save`, to the chat application. When the user inputs `/save`, the chat history is saved to the `docs/chat_history.txt` file. This feature allows users to easily save and review their chat history.

#### refer https://github.com/neokd/NeoGPT/issues/136