### PR TITLE
Add /help command to `magic_commands.py`

### DIFF
--- a/neogpt/utils/magic_commands.py
+++ b/neogpt/utils/magic_commands.py
@@ -104,7 +104,19 @@ def magic_commands(user_input, chain):
         else:
             cprint("🚫 No chat history available. Start a conversation first.")
             return
+    
         
+    # If the user inputs '/help', print the list of available commands
+    elif user_input == "/help":
+        cprint("\n[bold magenta]📖 Available commands: [/bold magenta]")
+        cprint("🔄 /reset - Reset the chat session")
+        cprint("🚪 /exit - Exit the chat session")
+        cprint("📜 /history - Print the chat history")
+        cprint("💾 /save - Save the chat history to a file")
+        cprint("📋 /copy - Copy the last response from NeoGPT to the clipboard")
+        cprint("⏪ /undo - Remove the last response from the chat history")
+        return True
+
     # If the command is not recognized, print an error message
     else:
         cprint("Invalid command. Please try again.")


### PR DESCRIPTION
This pull request adds a new command, `/help`, to the `magic_commands.py` file. The `/help` command allows users to view a list of available commands in the chat session. This improves the user experience by providing a quick reference for available commands.