### PR TITLE
Add magic commands documentation

### DIFF
--- a/docs/guides/magic-commands.mdx
+++ b/docs/guides/magic-commands.mdx
@@ -3,3 +3,26 @@ title: Magic Commands
 description: "🚧 Our documentation is currently under construction! We're working hard to bring you the best information.Contributions are welcome! 🚧"
 ---
 
+# Magic Commands 🪄
+
+The `magic_commands.py` file contains a set of special commands that can be used during chat sessions. These commands, referred to as "magic commands" 🪄, provide additional functionalities:
+
+- `/reset` 🔄: This command resets the chat session. It clears the chat memory and starts a new session.
+
+- `/exit` 🚪: This command is used to exit the chat session.
+
+- `/history` 📜: This command prints the chat history. It displays all the messages exchanged during the chat session.
+
+- `/save` 💾: This command saves the chat history to a file. The file is named as `chat_history_{timestamp}.txt`, where `{timestamp}` is the current date and time.
+
+- `/copy` 📋: This command copies the last response from NeoGPT to the clipboard.
+
+- `/undo` ↩️: This command removes the last response from the chat history.
+
+- `/redo` 🔁: This command resends the last human input to the model.
+
+- `/help` ❓: This command displays a help message with the list of available commands.
+
+If a command is not recognized, an error message is displayed 🚫.
+
+To use a magic command, simply type the command in the chat session and press enter ⌨️.

--- a/docs/guides/magic-commands.mdx
+++ b/docs/guides/magic-commands.mdx
@@ -1,8 +1,3 @@
----
-title: Magic Commands
-description: "🚧 Our documentation is currently under construction! We're working hard to bring you the best information.Contributions are welcome! 🚧"
----
-
 # Magic Commands 🪄
 
 The `magic_commands.py` file contains a set of special commands that can be used during chat sessions. These commands, referred to as "magic commands" 🪄, provide additional functionalities:


### PR DESCRIPTION
This pull request adds documentation for the magic commands feature. The `magic_commands.py` file now contains a set of special commands that can be used during chat sessions. These commands provide additional functionalities such as resetting the chat session, exiting the chat session, printing the chat history, saving the chat history to a file, copying the last response from NeoGPT to the clipboard, undoing the last response, redoing the last human input, and displaying a help message with the list of available commands.

#### refer #170