### PR TITLE
Fix regex pattern in read_file.py

### DIFF
--- a/neogpt/utils/read_file.py
+++ b/neogpt/utils/read_file.py
@@ -15,7 +15,7 @@ def convert_to_base64(pil_image):
     Convert PIL images to Base64 encoded strings
 
     :param pil_image: PIL image
-    :return: Re-sized Base64 string
+    :return: Re-sized BSase64 string
     """
     # Convert image to 'RGB' mode to avoid 'RGBA' mode issues
     pil_image = pil_image.convert("RGB")
@@ -28,7 +28,7 @@ def convert_to_base64(pil_image):
 
 def read_file(user_input, chain):
     regex = re.compile(
-        r"(?:[a-zA-Z]:)?(?:\.?/|\\)?[^:<>:\"/|?*]*\.(?i:txt|pdf|png|jpg|svg|jpeg|py|csv|doc|docx|ppt|pptx|xls|xlsx)\b"
+        r"(?:[a-zA-Z]:)?(?:\.?/|\\)?(?:[^:<>\"/|?*\n\r]+)?\.(?i:txt|pdf|png|jpg|svg|jpeg|py|csv|doc|docx|ppt|pptx|xls|xlsx)\b"
     )
     file_paths = [match.group(0) for match in regex.finditer(user_input)]
 

--- a/neogpt/utils/read_file.py
+++ b/neogpt/utils/read_file.py
@@ -28,7 +28,7 @@ def convert_to_base64(pil_image):
 
 def read_file(user_input, chain):
     regex = re.compile(
-        r"(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:txt|pdf|png|jpg|svg|jpeg|py|csv|doc|docx|ppt|pptx|xls|xlsx)\b"
+        r"(?:[a-zA-Z]:)?(?:\.?/|\\)?[^:<>:\"/|?*]*\.(?i:txt|pdf|png|jpg|svg|jpeg|py|csv|doc|docx|ppt|pptx|xls|xlsx)\b"
     )
     file_paths = [match.group(0) for match in regex.finditer(user_input)]
 


### PR DESCRIPTION
This pull request fixes the regex pattern in the read_file.py file. The previous pattern had a typo that caused it to not match certain file paths correctly. The updated pattern now correctly matches file paths with special characters and handles both forward slashes and backslashes as path separators.

#### refer #199